### PR TITLE
Add upload and pull-through cache feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,100 @@
 
 A Pulp plugin to support hosting your own conda.
 
-For more information, please see the [documentation](docs/index.md) or the [Pulp project page](https://pulpproject.org/).
+## Package upload
 
+In order to upload a conda package to Pulp there are two steps that have to be done:
 
-How to File an Issue
---------------------
+1. Upload the package
+1. Upload the corresponding ```repodata.json``` for the ```noarch``` and your own architecture
 
-File through this project's GitHub issues and appropriate labels.
+### Workflow
 
-> **WARNING** Is this security related? If so, please follow the [Security Disclosures](https://docs.pulpproject.org/pulpcore/bugs-features.html#security-bugs) procedure.
+1. Create a ```noarch``` repository. **Without a ```noarch``` repository the ```conda``` CLI will not work!**
+```sh
+curl -sk -u <username>:<password> -X POST "<base_url>/pulp/api/v3/repositories/conda/conda/" \
+-d '{"name": "noarch"}' \
+-H "Content-Type: application/json"
+```
+
+2. Create a repository for your architecture. We suggest that you follow the naming convention of supported conda architectures, i.e. ```linux-32, linux-64, linux-aarch64, linux-armv6l, linux-armv7l, linux-ppc64cle, linux-s390x, noarch, osx-64, osx-arm64, win-32, win-64```.
+```sh
+curl -sk -u <username>:<password> -X POST "<base_url>/pulp/api/v3/repositories/conda/conda/" \
+-d '{"name": "<repository_name>"}' \
+-H "Content-Type: application/json"
+```
+
+3. Create a ```noarch``` distribution. **Without a ```noarch``` distribution the ```conda``` CLI will not work!**
+```sh
+curl -sk -u <username>:<password> -X POST "<base_url>/pulp/api/v3/distributions/conda/conda/" \
+-d '{"name": "noarch", "base_path": "noarch", "repository": "<noarch_repository_href>"}' \
+-H "Content-Type: application/json"
+```
+
+4. Create a distribution for your architecture. **The ```base_path``` needs to follow the naming convention of supported conda architectures for the ```conda``` CLI to work, i.e. ```linux-32, linux-64, linux-aarch64, linux-armv6l, linux-armv7l, linux-ppc64cle, linux-s390x, noarch, osx-64, osx-arm64, win-32, win-64```.**
+```sh
+curl -sk -u <username>:<password> -X POST "<base_url>/pulp/api/v3/distributions/conda/conda/" \
+-d '{"name": "<distribution_name>", "base_path": "<base_path>", "repository": "<repository_href>"}' \
+-H "Content-Type: application/json"
+```
+
+5. Upload a package and attach it to the repository for your architecture. A new repository version is automatically crated.
+```sh
+curl -sk -u <username>:<password> "<base_url>/pulp/api/v3/content/conda/packages/" \
+-F "file=@<path_to_file>" -F "repository=<repository_name>"
+```
+
+6. Upload a ```repodata.json``` for the ```noarch``` repository. **Without a ```repodata.json``` in the ```noarch``` repository, the ```conda``` CLI will not work!**
+```sh
+curl -sk -u <username>:<password> "<base_url>/pulp/api/v3/content/conda/repodatas/" \
+-F "file=@<path_to_file>" -F "repository=noarch"
+```
+
+7. Upload a ```repodata.json``` for your architecture. **Without a ```repodata.json``` the ```conda``` CLI will cannot resolve your package!**
+```sh
+curl -sk -u <username>:<password> "<base_url>/pulp/api/v3/content/conda/repodatas/" \
+-F "file=@<path_to_file>" -F "repository=<repository_name>"
+```
+
+## Pull-through Cache
+
+In order to enable the pull-through cache feature one needs to create a remote which points to the reopsitory to be pulled from and a distribution to serve it from the Pulp server.
+
+1. Create a ```noarch``` remote to a repository (e.g. ```https://repo.anaconda.com/pkgs/main/noarch```). **Without a ```noarch``` distribution the ```conda``` CLI will not work!**
+```sh
+curl -sk -u <user>:<password> -X POST "<base_url>/pulp/api/v3/remotes/conda/conda/" \
+-d '{"name": "noarch", "url": "<noarch_remote_url>"}' \
+-H 'Content-Type: application/json'
+```
+
+2. Create a remote to a repository for your architecture (e.g. ```https://repo.anaconda.com/pkgs/main/<architecture>```). We suggest that you follow the naming convention of supported conda architectures, i.e. ```linux-32, linux-64, linux-aarch64, linux-armv6l, linux-armv7l, linux-ppc64cle, linux-s390x, noarch, osx-64, osx-arm64, win-32, win-64```.
+```sh
+curl -sk -u <user>:<password> -X POST "<base_url>/pulp/api/v3/remotes/conda/conda/" \
+-d '{"name": "<remote_name>", "url": "<remote_url>"}' \
+-H 'Content-Type: application/json'
+```
+
+3. Create a ```noarch``` distribution and link the ````noarch``` remote to it. **Without a ```noarch``` distribution the ```conda``` CLI will not work!**
+```sh
+curl -sk -u <username>:<password> -X POST "<base_url>/pulp/api/v3/distributions/conda/conda/" \
+-d '{"name": "cache/noarch", "base_path": "cache/noarch", "remote": "<noarch_remote_href>"}' \
+-H "Content-Type: application/json"
+```
+
+4. Create a distribution for your architecture and link the remote to it. **The ```base_path``` needs to follow the naming convention of supported conda architectures for the ```conda``` CLI to work, i.e. ```linux-32, linux-64, linux-aarch64, linux-armv6l, linux-armv7l, linux-ppc64cle, linux-s390x, noarch, osx-64, osx-arm64, win-32, win-64```.**
+```sh
+curl -sk -u <username>:<password> -X POST "<base_url>/pulp/api/v3/distributions/conda/conda/" \
+-d '{"name": "cache/<distribution_name>", "base_path": "cache/<base_path>", "remote": "<remote_href>"}' \
+-H "Content-Type: application/json"
+```
+
+## Conda CLI configuration
+
+If you have followed all instructions above you can now replace the channels in your ```conda``` configuration file.
+```sh
+channels:
+  - http://localhost/pulp/content/
+  - http://localhost/pulp/content/cache/
+```
+
+This first channel looks for the package in the repositories where you upload your own packages and the second channel is the pull-through cache you set up. Therefore, all downloads of packages go through the Pulp server.

--- a/README.md
+++ b/README.md
@@ -7,35 +7,35 @@ A Pulp plugin to support hosting your own conda.
 In order to upload a conda package to Pulp there are two steps that have to be done:
 
 1. Upload the package
-1. Upload the corresponding ```repodata.json``` for the ```noarch``` and your own architecture
+1. Upload the corresponding `repodata.json` for the `noarch` and your own architecture
 
 ### Workflow
 
-1. Create a ```noarch``` repository. **Without a ```noarch``` repository the ```conda``` CLI will not work!**
+1. Create a `noarch` repository. **Without a `noarch` repository the `conda` CLI will not work!**
 ```sh
 curl -sk -u <username>:<password> -X POST "<base_url>/pulp/api/v3/repositories/conda/conda/" \
--d '{"name": "noarch"}' \
+-d '{"name": "conda/noarch"}' \
 -H "Content-Type: application/json"
 ```
 
-2. Create a repository for your architecture. We suggest that you follow the naming convention of supported conda architectures, i.e. ```linux-32, linux-64, linux-aarch64, linux-armv6l, linux-armv7l, linux-ppc64cle, linux-s390x, noarch, osx-64, osx-arm64, win-32, win-64```.
+2. Create a repository for your architecture. We suggest that you follow the naming convention of supported conda architectures, i.e. `linux-32, linux-64, linux-aarch64, linux-armv6l, linux-armv7l, linux-ppc64cle, linux-s390x, noarch, osx-64, osx-arm64, win-32, win-64`.
 ```sh
 curl -sk -u <username>:<password> -X POST "<base_url>/pulp/api/v3/repositories/conda/conda/" \
--d '{"name": "<repository_name>"}' \
+-d '{"name": "conda/<repository_name>"}' \
 -H "Content-Type: application/json"
 ```
 
-3. Create a ```noarch``` distribution. **Without a ```noarch``` distribution the ```conda``` CLI will not work!**
+3. Create a `noarch` distribution. **Without a `noarch` distribution the `conda` CLI will not work!**
 ```sh
 curl -sk -u <username>:<password> -X POST "<base_url>/pulp/api/v3/distributions/conda/conda/" \
--d '{"name": "noarch", "base_path": "noarch", "repository": "<noarch_repository_href>"}' \
+-d '{"name": "conda/noarch", "base_path": "conda/noarch", "repository": "<noarch_repository_href>"}' \
 -H "Content-Type: application/json"
 ```
 
-4. Create a distribution for your architecture. **The ```base_path``` needs to follow the naming convention of supported conda architectures for the ```conda``` CLI to work, i.e. ```linux-32, linux-64, linux-aarch64, linux-armv6l, linux-armv7l, linux-ppc64cle, linux-s390x, noarch, osx-64, osx-arm64, win-32, win-64```.**
+4. Create a distribution for your architecture. **The `base_path` needs to follow the naming convention of supported conda architectures for the `conda` CLI to work, i.e. `linux-32, linux-64, linux-aarch64, linux-armv6l, linux-armv7l, linux-ppc64cle, linux-s390x, noarch, osx-64, osx-arm64, win-32, win-64`.**
 ```sh
 curl -sk -u <username>:<password> -X POST "<base_url>/pulp/api/v3/distributions/conda/conda/" \
--d '{"name": "<distribution_name>", "base_path": "<base_path>", "repository": "<repository_href>"}' \
+-d '{"name": "conda/<distribution_name>", "base_path": "conda/<base_path>", "repository": "<repository_href>"}' \
 -H "Content-Type: application/json"
 ```
 
@@ -45,57 +45,72 @@ curl -sk -u <username>:<password> "<base_url>/pulp/api/v3/content/conda/packages
 -F "file=@<path_to_file>" -F "repository=<repository_name>"
 ```
 
-6. Upload a ```repodata.json``` for the ```noarch``` repository. **Without a ```repodata.json``` in the ```noarch``` repository, the ```conda``` CLI will not work!**
+6. Upload a `repodata.json` for the `noarch` repository. **Without a `repodata.json` in the `noarch` repository, the `conda` CLI will not work!**
 ```sh
 curl -sk -u <username>:<password> "<base_url>/pulp/api/v3/content/conda/repodatas/" \
--F "file=@<path_to_file>" -F "repository=noarch"
+-F "file=@<path_to_file>" -F "repository=conda/noarch"
 ```
 
-7. Upload a ```repodata.json``` for your architecture. **Without a ```repodata.json``` the ```conda``` CLI will cannot resolve your package!**
+7. Upload a `repodata.json` for your architecture. **Without a `repodata.json` the `conda` CLI will cannot resolve your package!**
 ```sh
 curl -sk -u <username>:<password> "<base_url>/pulp/api/v3/content/conda/repodatas/" \
 -F "file=@<path_to_file>" -F "repository=<repository_name>"
 ```
 
+### Conda CLI configuration
+
+If you have followed all instructions above you can now replace the channels in your `conda` configuration file.
+```sh
+channels:
+  - http://localhost/pulp/content/conda/
+```
+
+The `conda` CLI automatically adds the suffix for the architecture used (e.g. `linux-64`) and looks for the `repodata.json` files in the `noarch` repository and architecture repository (e.g. `linux-64`).
+
 ## Pull-through Cache
 
 In order to enable the pull-through cache feature one needs to create a remote which points to the reopsitory to be pulled from and a distribution to serve it from the Pulp server.
 
-1. Create a ```noarch``` remote to a repository (e.g. ```https://repo.anaconda.com/pkgs/main/noarch```). **Without a ```noarch``` distribution the ```conda``` CLI will not work!**
+1. Create a `noarch` remote to a repository (e.g. `https://repo.anaconda.com/pkgs/main/noarch`). **Without a `noarch` distribution the `conda` CLI will not work!**
 ```sh
 curl -sk -u <user>:<password> -X POST "<base_url>/pulp/api/v3/remotes/conda/conda/" \
--d '{"name": "noarch", "url": "<noarch_remote_url>"}' \
+-d '{"name": "conda/noarch", "url": "<noarch_remote_url>"}' \
 -H 'Content-Type: application/json'
 ```
 
-2. Create a remote to a repository for your architecture (e.g. ```https://repo.anaconda.com/pkgs/main/<architecture>```). We suggest that you follow the naming convention of supported conda architectures, i.e. ```linux-32, linux-64, linux-aarch64, linux-armv6l, linux-armv7l, linux-ppc64cle, linux-s390x, noarch, osx-64, osx-arm64, win-32, win-64```.
+2. Create a remote to a repository for your architecture (e.g. `https://repo.anaconda.com/pkgs/main/<architecture>`). We suggest that you follow the naming convention of supported conda architectures, i.e. `linux-32, linux-64, linux-aarch64, linux-armv6l, linux-armv7l, linux-ppc64cle, linux-s390x, noarch, osx-64, osx-arm64, win-32, win-64`.
 ```sh
 curl -sk -u <user>:<password> -X POST "<base_url>/pulp/api/v3/remotes/conda/conda/" \
--d '{"name": "<remote_name>", "url": "<remote_url>"}' \
+-d '{"name": "conda/<remote_name>", "url": "<remote_url>"}' \
 -H 'Content-Type: application/json'
 ```
 
-3. Create a ```noarch``` distribution and link the ````noarch``` remote to it. **Without a ```noarch``` distribution the ```conda``` CLI will not work!**
+3. Create a `noarch` distribution and link the `noarch` remote to it. **Without a `noarch` distribution the `conda` CLI will not work!**
 ```sh
 curl -sk -u <username>:<password> -X POST "<base_url>/pulp/api/v3/distributions/conda/conda/" \
--d '{"name": "cache/noarch", "base_path": "cache/noarch", "remote": "<noarch_remote_href>"}' \
+-d '{"name": "conda/cache/noarch", "base_path": "conda/cache/noarch", "remote": "<noarch_remote_href>"}' \
 -H "Content-Type: application/json"
 ```
 
-4. Create a distribution for your architecture and link the remote to it. **The ```base_path``` needs to follow the naming convention of supported conda architectures for the ```conda``` CLI to work, i.e. ```linux-32, linux-64, linux-aarch64, linux-armv6l, linux-armv7l, linux-ppc64cle, linux-s390x, noarch, osx-64, osx-arm64, win-32, win-64```.**
+4. Create a distribution for your architecture and link the remote to it. **The `base_path` needs to follow the naming convention of supported conda architectures for the `conda` CLI to work, i.e. `linux-32, linux-64, linux-aarch64, linux-armv6l, linux-armv7l, linux-ppc64cle, linux-s390x, noarch, osx-64, osx-arm64, win-32, win-64`.**
 ```sh
 curl -sk -u <username>:<password> -X POST "<base_url>/pulp/api/v3/distributions/conda/conda/" \
--d '{"name": "cache/<distribution_name>", "base_path": "cache/<base_path>", "remote": "<remote_href>"}' \
+-d '{"name": "conda/cache/<distribution_name>", "base_path": "conda/cache/<base_path>", "remote": "<remote_href>"}' \
 -H "Content-Type: application/json"
 ```
 
-## Conda CLI configuration
+### Conda CLI configuration
 
-If you have followed all instructions above you can now replace the channels in your ```conda``` configuration file.
+If you have followed all instructions above you can now replace the channels in your `conda` configuration file.
 ```sh
 channels:
-  - http://localhost/pulp/content/
-  - http://localhost/pulp/content/cache/
+  - http://localhost/pulp/content/conda/cache/
 ```
 
-This first channel looks for the package in the repositories where you upload your own packages and the second channel is the pull-through cache you set up. Therefore, all downloads of packages go through the Pulp server.
+The `conda` CLI automatically adds the suffix for the architecture used (e.g. `linux-64`) and looks for the `repodata.json` files in the `noarch` repository and architecture repository (e.g. `linux-64`).
+
+## How to create `repodata.json` files for your packages
+
+A detailed description on how to create `repodata.json` files for your packages can be found here: https://docs.conda.io/projects/conda-build/en/latest/concepts/generating-index.html
+
+Note that without an up-to-date `repodata.json` in your repository, the `conda` CLI cannot find the correct packages! Therefore, the `repodata.json` has to be created manually for **ALL** packages in the repository. That means that you need to find a way to have all packages on your disk to create the `repodata.json`, i.e. all packages that you want to have in your repository version need to be downloaded in order to create the `repodata.json`.

--- a/pulp_conda/app/models.py
+++ b/pulp_conda/app/models.py
@@ -1,10 +1,3 @@
-"""
-Check `Plugin Writer's Guide`_ for more details.
-
-.. _Plugin Writer's Guide:
-    https://pulpproject.org/pulpcore/docs/dev/
-"""
-
 from logging import getLogger
 
 from django.db import models
@@ -19,36 +12,76 @@ from pulpcore.plugin.models import (
 )
 from pulpcore.plugin.util import get_domain_pk
 
+from .utils import extract_package_info
+
 logger = getLogger(__name__)
 
 
-class CondaContent(Content):
+class Package(Content):
     """
     The "conda" content type.
 
-    Define fields you need for your new content type and
-    specify uniqueness constraint to identify unit of this type.
+    Content of this type represents a single conda package uniquely identified by name, version, build and platform.
 
-    For example::
-
-        field1 = models.TextField()
-        field2 = models.IntegerField()
-        field3 = models.CharField()
-
-        class Meta:
-            default_related_name = "%(app_label)s_%(model_name)s"
-            unique_together = ("field1", "field2")
+    Fields:
+        name (str): The name of the conda package.
+        version (str): The version of the conda package.
+        build (str): The build number of the conda package.
+        extension (str): The extension of the conda package.
     """
 
-    TYPE = "conda"
+    TYPE = "package"
 
-    name = models.CharField(blank=False, null=False)
+    name = models.CharField(max_length=255)
+    version = models.CharField(max_length=255)
+    build = models.CharField(max_length=255)
+    extension = models.CharField(max_length=8)
     _pulp_domain = models.ForeignKey("core.Domain", default=get_domain_pk, on_delete=models.PROTECT)
+
+    @property
+    def relative_path(self):
+        """
+        Returns relative_path.
+        """
+        return f"{self.name}-{self.version}-{self.build}.{self.extension}"
+
+    @staticmethod
+    def init_from_artifact_and_relative_path(artifact, relative_path):
+        name, version, build, extension = extract_package_info(relative_path)
+
+        return Package(name=name, version=version, build=build, extension=extension)
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
-        unique_together = ("name", "_pulp_domain")
+        unique_together = ("name", "version", "build", "extension", "_pulp_domain")
 
+class Repodata(Content):
+    """
+    The "repodata" content type.
+
+    Content of this type represents a single conda package uniquely identified by name, version, build and platform.
+
+    Fields:
+        digest (str): The SHA256 HEX digest of the repodata.json.
+    """
+
+    PROTECTED_FROM_RECLAIM = False
+
+    TYPE = "repodata"
+
+    digest = models.CharField(max_length=64, null=False)
+    _pulp_domain = models.ForeignKey("core.Domain", default=get_domain_pk, on_delete=models.PROTECT)
+
+    @property
+    def relative_path(self):
+        """
+        Returns relative_path.
+        """
+        return "repodata.json"
+
+    class Meta:
+        default_related_name = "%(app_label)s_%(model_name)s"
+        unique_together = ("digest", "_pulp_domain")
 
 class CondaPublication(Publication):
     """
@@ -72,6 +105,14 @@ class CondaRemote(Remote):
 
     TYPE = "conda"
 
+    def get_remote_artifact_content_type(self, relative_path=None):
+        name, version, build, extension = extract_package_info(relative_path)
+
+        if None in [name, version, build, extension]:
+            return None
+
+        return Package
+
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
 
@@ -85,7 +126,10 @@ class CondaRepository(Repository):
 
     TYPE = "conda"
 
-    CONTENT_TYPES = [CondaContent]
+    CONTENT_TYPES = [Package, Repodata]
+    REMOTE_TYPES = [CondaRemote]
+
+    PULL_THROUGH_SUPPORTED = True
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"

--- a/pulp_conda/app/tasks/__init__.py
+++ b/pulp_conda/app/tasks/__init__.py
@@ -1,2 +1,2 @@
-from .publishing import publish  # noqa
+from .publishing import publish_package, publish_repodata  # noqa
 from .synchronizing import synchronize  # noqa

--- a/pulp_conda/app/tasks/publishing.py
+++ b/pulp_conda/app/tasks/publishing.py
@@ -25,7 +25,6 @@ def publish_package(repository_pk, package_pk):
     """
 
     repository = CondaRepository.objects.get(pk=repository_pk)
-    distribution = CondaDistribution.objects.get(repository=repository)
 
     with repository.new_version() as new_version:
         new_version.add_content(Package.objects.filter(pk=package_pk))
@@ -40,7 +39,6 @@ def publish_repodata(repository_pk, repodata_pk):
     """
 
     repository = CondaRepository.objects.get(pk=repository_pk)
-    distribution = CondaDistribution.objects.get(repository=repository)
 
     with repository.new_version() as new_version:
         # Since there should always only be one repodata.json in a given repository, it is save to delete all objects.

--- a/pulp_conda/app/tasks/publishing.py
+++ b/pulp_conda/app/tasks/publishing.py
@@ -25,11 +25,10 @@ def publish_package(repository_pk, package_pk):
     """
 
     repository = CondaRepository.objects.get(pk=repository_pk)
-    package = Package.objects.get(pk=package_pk)
     distribution = CondaDistribution.objects.get(repository=repository)
 
     with repository.new_version(base_version=repository.latest_version()) as new_version:
-        new_version.add_content(Package.objects.filter(pk=package.pk))
+        new_version.add_content(Package.objects.filter(pk=package_pk))
 
     distribution.repository_version = new_version
     distribution.save()
@@ -44,7 +43,6 @@ def publish_repodata(repository_pk, repodata_pk):
     """
 
     repository = CondaRepository.objects.get(pk=repository_pk)
-    repodata = Repodata.objects.get(pk=repodata_pk)
     distribution = CondaDistribution.objects.get(repository=repository)
 
     with repository.new_version(base_version=repository.latest_version()) as new_version:
@@ -52,7 +50,7 @@ def publish_repodata(repository_pk, repodata_pk):
         # All objects = last uploaded repodata.json. This is needed because otherwise there are two files with the same
         # relative_path and Pulp does not know which one to serve.
         new_version.remove_content(Repodata.objects.all())
-        new_version.add_content(Repodata.objects.filter(pk=repodata.pk))
+        new_version.add_content(Repodata.objects.filter(pk=repodata_pk))
 
     distribution.repository_version = new_version
     distribution.save()

--- a/pulp_conda/app/tasks/publishing.py
+++ b/pulp_conda/app/tasks/publishing.py
@@ -30,9 +30,6 @@ def publish_package(repository_pk, package_pk):
     with repository.new_version() as new_version:
         new_version.add_content(Package.objects.filter(pk=package_pk))
 
-    distribution.repository_version = new_version
-    distribution.save()
-
 def publish_repodata(repository_pk, repodata_pk):
     """
     Create a new Repository version when a new repodata is uploaded and switch distribution to new version.
@@ -51,6 +48,3 @@ def publish_repodata(repository_pk, repodata_pk):
         # relative_path and Pulp does not know which one to serve.
         new_version.remove_content(Repodata.objects.all())
         new_version.add_content(Repodata.objects.filter(pk=repodata_pk))
-
-    distribution.repository_version = new_version
-    distribution.save()

--- a/pulp_conda/app/tasks/publishing.py
+++ b/pulp_conda/app/tasks/publishing.py
@@ -27,7 +27,7 @@ def publish_package(repository_pk, package_pk):
     repository = CondaRepository.objects.get(pk=repository_pk)
     distribution = CondaDistribution.objects.get(repository=repository)
 
-    with repository.new_version(base_version=repository.latest_version()) as new_version:
+    with repository.new_version() as new_version:
         new_version.add_content(Package.objects.filter(pk=package_pk))
 
     distribution.repository_version = new_version
@@ -45,7 +45,7 @@ def publish_repodata(repository_pk, repodata_pk):
     repository = CondaRepository.objects.get(pk=repository_pk)
     distribution = CondaDistribution.objects.get(repository=repository)
 
-    with repository.new_version(base_version=repository.latest_version()) as new_version:
+    with repository.new_version() as new_version:
         # Since there should always only be one repodata.json in a given repository, it is save to delete all objects.
         # All objects = last uploaded repodata.json. This is needed because otherwise there are two files with the same
         # relative_path and Pulp does not know which one to serve.

--- a/pulp_conda/app/tasks/synchronizing.py
+++ b/pulp_conda/app/tasks/synchronizing.py
@@ -9,7 +9,7 @@ from pulpcore.plugin.stages import (
     Stage,
 )
 
-from pulp_conda.app.models import CondaContent, CondaRemote
+from pulp_conda.app.models import Package, CondaRemote
 
 
 log = logging.getLogger(__name__)

--- a/pulp_conda/app/utils.py
+++ b/pulp_conda/app/utils.py
@@ -1,0 +1,22 @@
+import re
+
+
+def extract_package_info(relative_path):
+    """ "
+    Tries to extract the name, version and build of a package from the (relative) path string.
+
+    Args:
+      The (relative) path string. "name-version-build.{conda,tar.bz2}"
+    """
+
+    pattern = r"^(?P<name>.+)-(?P<version>\d.+)-(?P<build>.+)\.(?P<extension>conda|tar\.bz2)$"
+    match = re.match(pattern, relative_path)
+
+    if match:
+        name = match.group("name")
+        version = match.group("version")
+        build = match.group("build")
+        extension = match.group("extension")
+        return name, version, build, extension
+    else:
+        return None, None, None, None

--- a/pulp_conda/app/viewsets.py
+++ b/pulp_conda/app/viewsets.py
@@ -1,11 +1,5 @@
-"""
-Check `Plugin Writer's Guide`_ for more details.
-
-.. _Plugin Writer's Guide:
-    https://pulpproject.org/pulpcore/docs/dev/
-"""
-
 from django.db import transaction
+from django_filters import CharFilter
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.decorators import action
@@ -19,93 +13,192 @@ from pulpcore.plugin.serializers import (
     RepositorySyncURLSerializer,
 )
 from pulpcore.plugin.tasking import dispatch
-from pulpcore.plugin.models import ContentArtifact
+from pulpcore.plugin.models import ContentArtifact, Artifact, PulpTemporaryFile
+
 
 from . import models, serializers, tasks
 
+from .utils import extract_package_info
 
-class CondaContentFilter(core.ContentFilter):
+
+class PackageFilter(core.ContentFilter):
     """
-    FilterSet for CondaContent.
+    FilterSet for Package.
     """
 
     class Meta:
-        model = models.CondaContent
+        model = models.Package
         fields = [
             # ...
         ]
 
 
-class CondaContentViewSet(core.ContentViewSet):
+class PackageViewSet(core.SingleArtifactContentUploadViewSet):
     """
-    A ViewSet for CondaContent.
+    A ViewSet for Package.
 
     Define endpoint name which will appear in the API endpoint for this content type.
     For example::
-        https://pulp.example.com/pulp/api/v3/content/conda/units/
+        https://pulp.example.com/pulp/api/v3/content/conda/packages/
 
-    Also specify queryset and serializer for CondaContent.
+    Also specify queryset and serializer for Package.
     """
 
-    endpoint_name = "conda"
-    queryset = models.CondaContent.objects.all()
-    serializer_class = serializers.CondaContentSerializer
-    filterset_class = CondaContentFilter
+    endpoint_name = "packages"
+    queryset = models.Package.objects.all()
+    serializer_class = serializers.PackageSerializer
+    filterset_class = PackageFilter
 
     @transaction.atomic
     def create(self, request):
         """
-        Perform bookkeeping when saving Content.
-
-        "Artifacts" need to be popped off and saved indpendently, as they are not actually part
-        of the Content model.
+        Handle conda package upload.
         """
-        return Response({}, status=status.HTTP_501_NOT_IMPLEMENTED)
-        # This requires some choice. Depending on the properties of your content type - whether it
-        # can have zero, one, or many artifacts associated with it, and whether any properties of
-        # the artifact bleed into the content type (such as the digest), you may want to make
-        # those changes here.
 
-        serializer = self.get_serializer(data=request.data)
+        # TODO: Wrap this in a try/catch block to check if file and repository are provided in the request
+        file = request.data["file"]
+        repository_name = request.data["repository"]
+
+        if not repository_name:
+            return None
+
+        name, version, build, extension = extract_package_info(file.name)
+
+        if None in [name, version, build, extension]:
+            return None
+
+        repository = models.CondaRepository.objects.get(name=repository_name)
+
+        try:
+            temp_file = PulpTemporaryFile(file=file)
+            artifact = Artifact.from_pulp_temporary_file(temp_file)
+        except Exception:
+            temp_file.delete()
+            # TODO: send correct response
+            return None
+
+        data = {
+            "name": name,
+            "version": version,
+            "build": build,
+            "extension": extension,
+            "relative_path": f"{name}-{version}-{build}.{extension}",
+        }
+
+        serializer = serializers.PackageSerializer(data=data)
         serializer.is_valid(raise_exception=True)
 
-        # A single artifact per content, serializer subclasses SingleArtifactContentSerializer
-        # ======================================
-        # _artifact = serializer.validated_data.pop("_artifact")
-        # # you can save model fields directly, e.g. .save(digest=_artifact.sha256)
-        # content = serializer.save()
-        #
-        # if content.pk:
-        #     ContentArtifact.objects.create(
-        #         artifact=artifact,
-        #         content=content,
-        #         relative_path= ??
-        #     )
-        # =======================================
+        package = models.Package.objects.filter(name=name, version=version, build=build, extension=extension).first()
+        if not package:
+            package = models.Package(
+                name = name,
+                version = version,
+                build = build,
+                extension = extension,
+            )
 
-        # Many artifacts per content, serializer subclasses MultipleArtifactContentSerializer
-        # =======================================
-        # _artifacts = serializer.validated_data.pop("_artifacts")
-        # content = serializer.save()
-        #
-        # if content.pk:
-        #   # _artifacts is a dictionary of {"relative_path": "artifact"}
-        #   for relative_path, artifact in _artifacts.items():
-        #       ContentArtifact.objects.create(
-        #           artifact=artifact,
-        #           content=content,
-        #           relative_path=relative_path
-        #       )
-        # ========================================
+            package.save()
 
-        # No artifacts, serializer subclasses NoArtifactContentSerialier
-        # ========================================
-        # content = serializer.save()
-        # ========================================
+            ContentArtifact.objects.create(
+                content = package,
+                artifact = artifact,
+                relative_path = package.relative_path,
+            )
 
-        headers = self.get_success_headers(serializer.data)
-        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+            result = dispatch(
+                tasks.publish_package,
+                kwargs = {"repository_pk": repository.pk, "package_pk": package.pk},
+                exclusive_resources = [repository, package],
+            )
 
+            return core.OperationPostponedResponse(result, request)
+        else:
+            artifact.delete()
+            # TODO: send correct response
+            return None
+
+class RepodataFilter(core.ContentFilter):
+    """
+    FilterSet for Repodata.
+    """
+
+    sha256 = CharFilter(field_name="digest")
+
+    class Meta:
+        model = models.Repodata
+        fields = ["sha256"]
+
+class RepodataViewSet(core.SingleArtifactContentUploadViewSet):
+    """
+    A ViewSet for Repodata.
+
+    Define endpoint name which will appear in the API endpoint for this content type.
+    For example:
+        https://pulp.example.com/pulp/api/v3/content/conda/repodatas/
+
+    Also specify queryset and serializer for Package.
+    """
+
+    endpoint_name = "repodatas"
+    queryset = models.Repodata.objects.all()
+    serializer_class = serializers.RepodataSerializer
+    filterset_class = RepodataFilter
+
+    @transaction.atomic
+    def create(self, request):
+        """
+        Handle repodata.json upload.
+        """
+
+        # TODO: Wrap this in a try/catch block to check if file and repository are provided in the request
+        file = request.data["file"]
+        repository_name = request.data["repository"]
+
+        if not repository_name:
+            return None
+
+        repository = models.CondaRepository.objects.get(name=repository_name)
+        try:
+            temp_file = PulpTemporaryFile(file=file)
+            artifact = Artifact.from_pulp_temporary_file(temp_file)
+        except Exception:
+            temp_file.delete()
+            # TODO: send correct response
+            return None
+
+        data = {
+            "digest": artifact.sha256,
+            "relative_path": "repodata.json",
+        }
+
+        serializer = serializers.RepodataSerializer(data=data)
+        serializer.is_valid(raise_exception=True)
+
+        repodata = models.Repodata.objects.filter(digest=artifact.sha256).first()
+        if not repodata:
+            repodata = models.Repodata(
+                digest = artifact.sha256,
+            )
+
+            repodata.save()
+
+            ContentArtifact.objects.create(
+                content = repodata,
+                artifact = artifact,
+                relative_path = repodata.relative_path,
+            )
+
+            result = dispatch(
+                tasks.publish_repodata,
+                kwargs = {"repository_pk": repository.pk, "repodata_pk": repodata.pk},
+                exclusive_resources = [repository, repodata],
+            )
+
+            return core.OperationPostponedResponse(result, request)
+        else:
+            artifact.delete()
+            # TODO: send correct response
+            return None
 
 class CondaRemoteFilter(RemoteFilter):
     """

--- a/pulp_conda/app/viewsets.py
+++ b/pulp_conda/app/viewsets.py
@@ -55,7 +55,6 @@ class PackageViewSet(core.SingleArtifactContentUploadViewSet):
         Handle conda package upload.
         """
 
-        # TODO: Wrap this in a try/catch block to check if file and repository are provided in the request
         file = request.data["file"]
         repository_name = request.data["repository"]
 
@@ -74,7 +73,6 @@ class PackageViewSet(core.SingleArtifactContentUploadViewSet):
             artifact = Artifact.from_pulp_temporary_file(temp_file)
         except Exception:
             temp_file.delete()
-            # TODO: send correct response
             return None
 
         data = {
@@ -114,7 +112,6 @@ class PackageViewSet(core.SingleArtifactContentUploadViewSet):
             return core.OperationPostponedResponse(result, request)
         else:
             artifact.delete()
-            # TODO: send correct response
             return None
 
 class RepodataFilter(core.ContentFilter):
@@ -150,7 +147,6 @@ class RepodataViewSet(core.SingleArtifactContentUploadViewSet):
         Handle repodata.json upload.
         """
 
-        # TODO: Wrap this in a try/catch block to check if file and repository are provided in the request
         file = request.data["file"]
         repository_name = request.data["repository"]
 
@@ -163,7 +159,6 @@ class RepodataViewSet(core.SingleArtifactContentUploadViewSet):
             artifact = Artifact.from_pulp_temporary_file(temp_file)
         except Exception:
             temp_file.delete()
-            # TODO: send correct response
             return None
 
         data = {
@@ -197,7 +192,6 @@ class RepodataViewSet(core.SingleArtifactContentUploadViewSet):
             return core.OperationPostponedResponse(result, request)
         else:
             artifact.delete()
-            # TODO: send correct response
             return None
 
 class CondaRemoteFilter(RemoteFilter):


### PR DESCRIPTION
It is now possible to upload a conda package and its corresponding repodata.json to the Pulp server and use a remote such that the Pulp server can function as a pull-through cache.